### PR TITLE
Fix potential overestimation of bitsPerWord for word-lists that aren't of length a power of 2

### DIFF
--- a/src/secret-to-words.ts
+++ b/src/secret-to-words.ts
@@ -27,7 +27,7 @@ const secretToWords = (
   secret: Uint8Array,
   options: PasswordLengthOptions = {}
 ): string[] => {
-    const bitsPerWord = Math.round(Math.log2(wordListOfLengthPowerOf2.length));
+    const bitsPerWord = Math.floor(Math.log2(wordListOfLengthPowerOf2.length));
     var {wordsNeeded, bitsNeeded} = options;
     if (typeof wordsNeeded !== "number") {
       if (typeof bitsNeeded != "number") {

--- a/src/secret-to-words.ts
+++ b/src/secret-to-words.ts
@@ -54,7 +54,7 @@ const secretToWords = (
       }
       const numBitsToCopy = Math.min(bitsLeftInByte, bitsNeededForWordIndex);
       // If we're only copying part of the byte, copy high-order bits and
-      // shift the remaining bits to the right.  (Shift any bits that
+      // zero out the used bits
       const bitsToCopy = (byte >> (bitsLeftInByte - numBitsToCopy));
       bitsLeftInByte -= numBitsToCopy;
       byte = byte & (0xff >> (8-bitsLeftInByte));


### PR DESCRIPTION
wordListOfLengthPowerOf2 is documented nominally as being of a length that is a power of 2, but the API protects itself from being passed a wordlist that isn't of length a power of 2 by using Math.round().  This overestimates the number of bitsPerWord for half of the wordlist lengths, which then underestimates the number of words required to use the number of available bits, or the number of words required to satisfy the bitsNeeded.